### PR TITLE
Switch to using password_hash for passwords

### DIFF
--- a/login.php
+++ b/login.php
@@ -71,27 +71,24 @@ function loginForm() {
 // Redirects to main page if successful
 function login($username, $pass) {
     if (!TRUST_REMOTE_USER) {
-        $sql = sprintf("SELECT uid FROM users WHERE
-            username='%s'
-            AND password=AES_ENCRYPT('%s', '%s%s')",
-                mysql_real_escape_string($username),
-                mysql_real_escape_string($pass),
-                mysql_real_escape_string($username),
-                mysql_real_escape_string($pass));
+        $uid = checkPassword($username, $pass);
+        if ($uid == FALSE) {
+            return FALSE;
+        }
     } else {
         $sql = sprintf("SELECT uid FROM users WHERE
             username='%s'",
             mysql_real_escape_string($username));
-    }
-    $result = query_db($sql);
-    if (mysql_num_rows($result) != 1) {
-        // Username/password combination not in database
-        return FALSE;
+        $result = query_db($sql);
+        if (mysql_num_rows($result) != 1) {
+            return FALSE;
+        }
+        $r = mysql_fetch_assoc($result);
+        $uid = $r['uid'];
     }
 
     // Store uid in SESSION
-    $r = mysql_fetch_assoc($result);
-    $_SESSION['uid'] = $r['uid'];
+    $_SESSION['uid'] = $uid;
     $_SESSION['SITEURL'] = URL;
 
     if (isset($_SESSION['redirect_to'])) {

--- a/register.php
+++ b/register.php
@@ -186,9 +186,9 @@ function register() {
             mysql_real_escape_string($username), mysql_real_escape_string($fullname), mysql_real_escape_string($email)
         );
     } else {
-        $sql = sprintf("INSERT INTO users (username, password, fullname, email, email_level) VALUES ('%s', AES_ENCRYPT('%s', '%s%s'), '%s', '%s', %s)",
-                       mysql_real_escape_string($username), mysql_real_escape_string($pass1),
-                       mysql_real_escape_string($username), mysql_real_escape_string($pass1),
+        $sql = sprintf("INSERT INTO users (username, password, fullname, email, email_level) VALUES ('%s', '%s', '%s', '%s', %s)",
+                       mysql_real_escape_string($username),
+                       mysql_real_escape_string(password_hash($pass1, PASSWORD_DEFAULT)),
                        mysql_real_escape_string($fullname), mysql_real_escape_string($email),
                        mysql_real_escape_string(DEFAULT_USER_EMAIL_LEVEL)
         );

--- a/schema.sql
+++ b/schema.sql
@@ -804,7 +804,7 @@ DROP TABLE IF EXISTS `users`;
 CREATE TABLE `users` (
   `uid` int(4) unsigned NOT NULL AUTO_INCREMENT,
   `username` varchar(32) NOT NULL,
-  `password` blob NOT NULL DEFAULT '' COMMENT 'AES_ENCRYPT(''password'',''usernamepassword'')',
+  `password` blob NOT NULL DEFAULT '' COMMENT 'password_hash(''password'')',
   `email` varchar(255) NOT NULL,
   `fullname` varchar(255) NOT NULL DEFAULT '',
   `picture` varchar(255) DEFAULT NULL,

--- a/seed.sql
+++ b/seed.sql
@@ -5,9 +5,12 @@
 LOCK TABLES `users` WRITE;
 /*!40000 ALTER TABLE `users` DISABLE KEYS */;
 INSERT INTO `users` VALUES
-(2,'abel', AES_ENCRYPT('abelpass', 'abelabelpass'), 'abel@example.com','Abel','',2),
-(3,'baker', AES_ENCRYPT('bakerpass', 'bakerbakerpass'), 'baker@example.com','Baker','',1),
-(4,'charlie', AES_ENCRYPT('charliepass', 'charliecharliepass'),'charlie@example.com','Charlie','',1);
+/* password is password_hash("abelpass", PASSWORD_DEFAULT) */
+(2,'abel','$2y$10$7Pi5PD87P5bZyqwwP9O81e5tBZCk9tQNTn0OW3lc0L4tK7zC8gjRm','abel@example.com','Abel','',2),
+/* password is password_hash("bakerpass", PASSWORD_DEFAULT) */
+(3,'baker','$2y$10$S7gBUVnHOlo5M5CdhFsMr.Ws98Pv4NasxITmtcFkZJDnsUKxb5Kka','baker@example.com','Baker','',1),
+/* password is password_hash("charliepass", PASSWORD_DEFAULT) */
+(4,'charlie','$2y$10$buVVorYaf0XDr7ce0NHIzeVwyjWYjtsbuFkidqHBONF9swBILkeaC','charlie@example.com','Charlie','',1);
 /*!40000 ALTER TABLE `users` ENABLE KEYS */;
 UNLOCK TABLES;
 


### PR DESCRIPTION
The previous code, which used MySQL's built-in AES_ENCRYPT, had a lot
of cryptographic problems. AES_ENCRYPT uses ECB, its key derivation
function is pretty lulzy, and it's completely unsalted.

The security requirements for Mystery Hunt aren't that substantial
(the likelihood of someone extracting and cracking the password
database seems low), but if someone re-uses a password on Puzzletron,
I'd like to store it in a safe way for the sake of the other sites
where they are using it.

This doesn't attempt to upgrade existing passwords, unless they're
changed. Everyone besides Death and Mayhem will probably never touch
their Puzzletron instance again, while we don't have any users yet.