### PR TITLE
Add back language about puzzle licensing

### DIFF
--- a/ansible/secrets.yml.example
+++ b/ansible/secrets.yml.example
@@ -113,6 +113,8 @@ apps:
         value: "https://sites.google.com/site/your-hunt-here"
       - key: PTRON_BUGTRACK_URL
         value: "https://github.com/mysteryhunt/puzzle-editing/issues"
+      - key: PTRON_LICENSEE_NAME
+        value: "Alyssa P. Hacker"
       - key: PTRON_MAILGUN_API_URL
         value: "https://api.mailgun.net/v2/your.mail.domain.here.example.com"
       - key: PTRON_MAILGUN_API_KEY
@@ -260,6 +262,8 @@ apps:
         value: "https://sites.google.com/site/your-hunt-here"
       - key: PTRON_BUGTRACK_URL
         value: "https://github.com/mysteryhunt/puzzle-editing/issues"
+      - key: PTRON_LICENSEE_NAME
+        value: "Alyssa P. Hacker"
       - key: PTRON_MAILGUN_API_URL
         value: "https://api.mailgun.net/v2/your.mail.domain.here.example.com"
       - key: PTRON_MAILGUN_API_KEY

--- a/config.php
+++ b/config.php
@@ -33,6 +33,7 @@ Dotenv::required(array(
     'PTRON_HELP_EMAIL',
     'PTRON_WIKI_URL',
     'PTRON_BUGTRACK_URL',
+    'PTRON_LICENSEE_NAME',
     'PTRON_MAILGUN_API_URL',
     'PTRON_MAILGUN_API_KEY',
     'PTRON_TRUST_REMOTE_USER',
@@ -102,6 +103,8 @@ define("PHPMYADMIN_URL", getenv('PTRON_PHPMYADMIN_URL'));
 define("HELP_EMAIL", getenv('PTRON_HELP_EMAIL'));
 define("WIKI_URL", getenv('PTRON_WIKI_URL'));
 define("BUGTRACK_URL", getenv('PTRON_BUGTRACK_URL'));
+
+define("LICENSEE_NAME", getenv('PTRON_LICENSEE_NAME'));
 
 define('MAILGUN_API_URL', getenv('PTRON_MAILGUN_API_URL'));
 define('MAILGUN_API_KEY', getenv('PTRON_MAILGUN_API_KEY'));

--- a/dotenv.example
+++ b/dotenv.example
@@ -71,6 +71,11 @@ PTRON_WIKI_URL="https://sites.google.com/site/blahblahblah"
 # This appears at the bottom of the homepage.
 PTRON_BUGTRACK_URL="https://github.com/mysteryhunt/puzzle-editing/issues"
 
+# When submitting new puzzles, authors will have to agree to license
+# their puzzles for redistribution. This specifies who they license
+# them to
+PTRON_LICENSEE_NAME="Alyssa P. Hacker"
+
 # Define these to use Mailgun for outgoing email.
 PTRON_MAILGUN_API_URL="https://api.mailgun.net/v2/your.mail.domain.here.example.com"
 PTRON_MAILGUN_API_KEY="key-3141592etcetc"

--- a/submit-new.php
+++ b/submit-new.php
@@ -84,6 +84,16 @@ function newIdeaForm($uid, $summary = '', $description = '') {
 ?>
     <h2>Puzzle Idea Submission</h2>
 
+    <p>Because running the Mystery Hunt and publishing the Hunt archive
+    effectively constitute redistributions of your copyrighted content, we need
+    to make sure we have the rights to do so. Authors will generally retain
+    creative control over their puzzles.</p>
+
+    <p>By submitting any puzzle-related content to Puzzletron, you agree to
+    grant <?php print LICENSEE_NAME ?> a perpetual, irrevocable, non-exclusive,
+    worldwide license to publish, modify, adapt, or relicense the Content in
+    any form.</p>
+
     <form method="post" action="submit-new.php">
         <p> Puzzle Title (NO SPOILERS):</p>
         <input type='text' name='title' maxlength='255' class="longin" />


### PR DESCRIPTION
Introduce a parameter to control who the license is to, so that
changing the license next year doesn't require a code change.