### PR TITLE
Spoil authors of a puzzle when it's submitted

### DIFF
--- a/submit-new.php
+++ b/submit-new.php
@@ -52,12 +52,15 @@ if (isset($_POST) && isset($_POST['newIdea'])) {
         mysql_real_escape_string($uid));
     query_db($sql);
 
+    addSpoiledUserQuietly($uid, $id);
+
     foreach ($coauthors as $author) {
         if ($author != $uid) {
             $sql = sprintf("INSERT INTO author_links (pid, uid) VALUES ('%s', '%s')",
                 mysql_real_escape_string($id),
                 mysql_real_escape_string($author));
             query_db($sql);
+            addSpoiledUserQuietly($author, $id);
         }
     }
 


### PR DESCRIPTION
Previously, authors were not immediately treated as spoiled on their
puzzle until they subsequently pull up the puzzle page.