### PR TITLE
Remove the "minimal email" option from puzzletron

### DIFF
--- a/edit-account.php
+++ b/edit-account.php
@@ -77,7 +77,6 @@ $data = getPerson($uid);
         <tr>
             <td>Update Email Preferences</td>
             <td>
-                <input type="radio" name="email_pref" value="0" <?php if ($data['email_level'] == 0) echo "checked" ?>/>Minimal Email<br/>
                 <input type="radio" name="email_pref" value="1" <?php if ($data['email_level'] == 1) echo "checked" ?>/>Human Comments on Puzzles<br/>
                 <input type="radio" name="email_pref" value="2" <?php if ($data['email_level'] == 2) echo "checked" ?>/>All Puzzle Updates<br/>
             </td>

--- a/utils.php
+++ b/utils.php
@@ -1152,7 +1152,7 @@ function emailComment($uid, $pid, $cleanComment, $isTestsolveComment = FALSE, $i
 
     foreach ($users as $user) {
         if ($user != $uid) {
-            if ((getEmailLevel($user) > 0 && $isImportant) || getEmailLevel($user) > 1) {
+            if ($isImportant || getEmailLevel($user) > 1) {
                 sendEmail($user, $subject, $message, $link);
             }
         }
@@ -1163,7 +1163,7 @@ function emailComment($uid, $pid, $cleanComment, $isTestsolveComment = FALSE, $i
         // author/editor/etc., they will get mail twice. This is
         // arguably not great, but we'll live with it.
         if ($user != $uid) {
-            if ((getEmailLevel($user) > 0 && $isImportant) || getEmailLevel($user) > 1) {
+            if ($isImportant || getEmailLevel($user) > 1) {
                 sendEmail($user, "[Testsolve] $subject", $message, $link);
             }
         }


### PR DESCRIPTION
As it turns out, "minimal email" actually means "no email", and it's
almost certainly never the case that you want that. Even if you think
you want that, I, as someone trying to run a hunt, don't want you to
be able to opt out of emails I want to send you.

r? @zarvox 