### PR TITLE
Add testsolve reminder emails

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,11 @@ volumes. Set up a Mailgun account and point Puzzletron at it using the
 - `docker-compose up`
 - Head to http://localhost:8000
 
+The docker environment does not run the cronjobs. To test running one of the
+PHP scripts that's designed to run as a cronjob, run `docker ps` and note the
+name of the `puzzleediting_php` container (likely `puzzleediting_php_1`) and
+then run `docker exec puzzleediting_php_1 php testsolve_reminder_cronjob.php`
+
 ## On your local machine using a LAMP stack
 
 If you're willing to contemplate running PHP, MySQL, and Apache on

--- a/config.php
+++ b/config.php
@@ -63,6 +63,7 @@ Dotenv::required(array(
     'PTRON_EDITOR_MAILING_LIST',
     'PTRON_HUNT_YEAR',
     'PTRON_HUNT_DOM',
+    'PTRON_TESTSOLVE_REMINDER_HOURS',
 ));
 
 # The code below wraps the config environment variables in PHP
@@ -123,6 +124,7 @@ define("MIN_APPROVERS", getenv('PTRON_MIN_APPROVERS'));
 define("APPROVALS_REQUIRED", getenv('PTRON_APPROVALS_REQUIRED'));
 
 define("REMINDER_EMAIL_DAYS", getenv('PTRON_REMINDER_EMAIL_DAYS'));
+define("TESTSOLVE_REMINDER_HOURS", getenv('PTRON_TESTSOLVE_REMINDER_HOURS'));
 
 define("HUNT_YEAR", getenv('PTRON_HUNT_YEAR'));
 define("HUNT_DOM", getenv('PTRON_HUNT_DOM'));

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       - ./docker/mysqldb:/var/lib/mysql
       - ./mysql:/etc/mysql/conf.d
     ports:
-      - "3306:3006"
+      - "3306:3306"
   composer:
     image: "composer:1.4.1"
     volumes:

--- a/docker/.env
+++ b/docker/.env
@@ -111,6 +111,11 @@ PTRON_APROVALS_REQUIRED="2"
 # authors for this many days
 PTRON_REMINDER_EMAIL_DAYS="0"
 
+# If set to a non-0 value, puzzletron will send a reminder email to anyone
+# who has been a testsolver on a puzzle for this many hours without
+# submitting a test report
+PTRON_TESTSOLVE_REMINDER_HOURS="48"
+
 # date of the next hunt - used to run the countdown on the home page
 PTRON_HUNT_YEAR="2017"
 # DOM = "Day of Month" - that month is January, of course

--- a/dotenv.example
+++ b/dotenv.example
@@ -115,6 +115,11 @@ PTRON_APROVALS_REQUIRED="2"
 # authors for this many days
 PTRON_REMINDER_EMAIL_DAYS="0"
 
+# If set to a non-0 value, puzzletron will send a reminder email to anyone
+# who has been a testsolver on a puzzle for this many hours without
+# submitting a test report
+PTRON_TESTSOLVE_REMINDER_HOURS="48"
+
 # date of the next hunt - used to run the countdown on the home page
 PTRON_HUNT_YEAR="2017"
 # DOM = "Day of Month" - that month is January, of course

--- a/schema.sql
+++ b/schema.sql
@@ -648,6 +648,7 @@ DROP TABLE IF EXISTS `tester_links`;
 CREATE TABLE `tester_links` (
   `uid` int(11) NOT NULL COMMENT 'User ID of Tester',
   `pid` int(11) NOT NULL COMMENT 'Puzzle ID',
+  `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT 'Time at which the user began testsolving',
   PRIMARY KEY (`uid`,`pid`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_unicode_ci;;
 /*!40101 SET character_set_client = @saved_cs_client */;

--- a/testsolve_reminder_cronjob.php
+++ b/testsolve_reminder_cronjob.php
@@ -1,0 +1,4 @@
+<?php // vim:set ts=4 sw=4 sts=4 et:
+require_once "utils.php";
+
+sendTestsolvingReminders();


### PR DESCRIPTION
Before running this code, we'll need to migrate the database with this command:

```
ALTER TABLE tester_links
  ADD COLUMN `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP;
```

This is safe to do before deploying the new code, and will automatically populate existing testsolving records with the current time.

The `schema.sql` file has been updated; if you're using the docker-compose environment you can load in the new schema and reset your test database by running `rm -rf docker/mysqldb; docker-compose build; docker-compose up`.

In the production environment, we'll also need to set the new `PTRON_TESTSOLVE_REMINDER_HOURS` environment variable (to `48`), and set up a cronjob to run `testsolve_reminder_cronjob.php` (this should run just before the email-sending job, because this cronjob populates the `email_outbox` table)
