### PR TITLE
Make cron work in prod dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,5 +49,6 @@ RUN chmod 0644 /etc/cron.d/ptron-cron && \
     apt-get -y install cron
 
 # Set up entrypoint
+ADD ./docker/prod/cron-entrypoint.sh /cron-entrypoint.sh
 ADD ./docker/prod/entrypoint.sh /entrypoint.sh
 CMD /entrypoint.sh

--- a/docker/prod/cron-entrypoint.sh
+++ b/docker/prod/cron-entrypoint.sh
@@ -1,0 +1,9 @@
+# Cron doesn't inherit env vars the container was started with so we save
+# our environment to .env
+env > /var/www/html/.env
+
+# Start cron and tail all the cron logs
+touch /var/log/cron.log
+touch /var/log/cron-email.out
+touch /var/log/cron-reminder.out
+cron && tail -F /var/log/cron*

--- a/docker/prod/ptron-cron
+++ b/docker/prod/ptron-cron
@@ -1,2 +1,2 @@
-* * * * * root ENVDIR=/var/www/html ENVFILE=.env php /var/www/html/email_cronjob.php
-*/5 * * * * root ENVDIR=/var/www/html ENVFILE=.env php /var/www/html/reminder_cronjob.php
+* * * * * root ENVDIR=/var/www/html ENVFILE=.env /usr/local/bin/php /var/www/html/email_cronjob.php > /var/log/cron-email.out 2>&1
+*/5 * * * * root ENVDIR=/var/www/html ENVFILE=.env /usr/local/bin/php /var/www/html/reminder_cronjob.php > /var/log/cron-reminder.out 2>&1

--- a/utils.php
+++ b/utils.php
@@ -3961,7 +3961,7 @@ function getModeFeedback($pid, $column_name) {
   if (count($arr) <= 0) {
     return "--";
   }
-  
+
   $count = array();
   foreach ($arr as $item) {
     if (isset($count[$item])) {
@@ -3999,7 +3999,7 @@ function sendReminderEmails() {
         LEFT OUTER JOIN pstatus s ON p.pstatus = s.id
         INNER JOIN comments c ON p.id = c.pid
         LEFT OUTER JOIN comments c2 ON p.id = c2.pid AND (c.timestamp < c2.timestamp OR (c.timestamp = c2.timestamp AND c.id < c2.id))
-        INNER JOIN (SELECT * FROM editor_links GROUP BY pid) el ON p.id = el.pid
+        INNER JOIN (SELECT pid FROM editor_links GROUP BY pid) el ON p.id = el.pid
         LEFT OUTER JOIN author_links al ON al.pid = p.id AND c.uid = al.uid
         WHERE c2.id IS NULL
         AND s.name != 'Awaiting Answer (Idea Approved)'


### PR DESCRIPTION
- Cron in docker doesn't inherit the environment variables the container was started with, so we now have an entrypoint that saves the current environment to `.env`

- Use the absolute path to `php`

- Send stdout and stderr from the jobs to log files and tail those

- The reminder cronjob was failing with `ERROR 1055 (42000): Expression #1 of SELECT list is not in GROUP BY clause and contains nonaggregated column 'puzzletron.editor_links.uid' which is not functionally dependent on columns in GROUP BY clause; this is incompatible with sql_mode=only_full_group_by`, probably because of a config different between GCP MySQL and our previous MySQL. I edited the query slightly in a way that I think is correct, but I'm not totally confident in my understanding of the query.